### PR TITLE
:sparkles: Add simple PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+# Merge Request Template
+
+## Description
+### What's new?
+...
+
+### What has changed?
+...
+
+### Extra information?
+...
+
+## Definition of Done
+### Code
+- [ ] Code voldoet aan alle genoemde eisen in de code conventions.
+- [ ] Code komt sterk overeen met gamedesign (User Story #1).
+- [ ] Code komt overeen met het technisch design, bij nodige afwijking wordt het diagram geupdate en de update gecommuniceerd met het hele team.
+- [ ] Code gedocumenteerd (comments).
+- [ ] Code gecontroleerd op (stilistische) fouten.
+- [ ] Unit tests geschreven en geslaagd voor nieuwe code.
+- [x] ~~Code is reviewed door minimaal één ander teamlid. Voor complexe danwel grote PR door minimaal 2 teamleden.~~ PR gerelateerd.
+- [ ] Aan alle in de story benoemde acceptatie criteria is voldaan.
+
+### Documentatie
+- [ ] Github wiki aangepast.
+
+### Testen
+- [ ] Alle (nieuwe) code runt lokaal op het systeem van de developer.
+- [ ] Alle gevonden bugs zijn onderkend en indien deze niet op korte termijn opgelost kunnen worden, als nieuw item opgenomen in de backlog.
+
+### Overige
+- [ ] User story in Taiga staat op Testing, wanneer getest op Done.


### PR DESCRIPTION
Adds a simple PR template containing the DoD. It should work in a dotfile folder, but I guess we won't know for sure until we merge :smiling_imp: